### PR TITLE
Initial migration of update services page

### DIFF
--- a/wordpress/update-services.md
+++ b/wordpress/update-services.md
@@ -1,15 +1,15 @@
 # Update Services
 
-Update Services are tools you can use to let other people know you’ve updated your blog. WordPress automatically notifies popular Update Services that you’ve updated your blog by sending a [XML-RPC](http://www.xmlrpc.com/) [ping](https://wordpress.org/support/article/glossary/#pingback) each time you create or update a post. In turn, Update Services process the ping and updates their proprietary indices with _your_ update. 
+Update Services are tools you can use to let other people know you've updated your blog. WordPress automatically notifies popular Update Services that you've updated your blog by sending a [XML-RPC](http://www.xmlrpc.com/) [ping](https://wordpress.org/support/article/glossary/#pingback) each time you create or update a post. In turn, Update Services process the ping and updates their proprietary indices with _your_ update. 
 
 ## Common Usage
 
-Most people use [Ping-o-Matic](https://pingomatic.com/) which, with just one “ping” from you, will let many other services know that you’ve updated. As for why, Ping-O-Matic puts it best:
+Most people use [Ping-o-Matic](https://pingomatic.com/) which, with just one "ping" from you, will let many other services know that you've updated. As for why, Ping-O-Matic puts it best:
 
 > Ping-O-Matic is a service to update different search engines that your blog has updated.
 > We regularly check downstream services to make sure that they're legit and still work. So while it may appear like we have fewer services, they're the most important ones.
 
-If you do not want the update services to be pinged, remove all the update service URIs listed under “Update Services” on the [Settings](https://wordpress.org/support/article/administration-screens/#settings-configuration-settings)->[Writing](https://wordpress.org/support/article/settings-writing-screen/) administration screen of your WordPress installation.
+If you do not want the update services to be pinged, remove all the update service URIs listed under "Update Services" on the [Settings](https://wordpress.org/support/article/administration-screens/#settings-configuration-settings)->[Writing](https://wordpress.org/support/article/settings-writing-screen/) administration screen of your WordPress installation.
 
 ![Screenshot of the Update Services screen.](https://wordpress.org/support/files/2018/10/update_service.png)
 
@@ -36,5 +36,4 @@ By default, editing the Ping Services for a WordPress Multisite network site is 
 
 ## Changelog
 
-- 2022-09-04: Nothing here, yet.
-- 2022-09-11: Migrated content from https://wordpress.org/support/article/update-services/
+- 2022-09-11: Migrated content from [Update Services](https://wordpress.org/support/article/update-services/)

--- a/wordpress/update-services.md
+++ b/wordpress/update-services.md
@@ -1,10 +1,40 @@
 # Update Services
 
-ORIGINAL CONTENT:
-* https://wordpress.org/support/article/update-services/
+Update Services are tools you can use to let other people know you’ve updated your blog. WordPress automatically notifies popular Update Services that you’ve updated your blog by sending a [XML-RPC](http://www.xmlrpc.com/) [ping](https://wordpress.org/support/article/glossary/#pingback) each time you create or update a post. In turn, Update Services process the ping and updates their proprietary indices with _your_ update. 
 
+## Common Usage
+
+Most people use [Ping-o-Matic](https://pingomatic.com/) which, with just one “ping” from you, will let many other services know that you’ve updated. As for why, Ping-O-Matic puts it best:
+
+> Ping-O-Matic is a service to update different search engines that your blog has updated.
+> We regularly check downstream services to make sure that they're legit and still work. So while it may appear like we have fewer services, they're the most important ones.
+
+If you do not want the update services to be pinged, remove all the update service URIs listed under “Update Services” on the [Settings](https://wordpress.org/support/article/administration-screens/#settings-configuration-settings)->[Writing](https://wordpress.org/support/article/settings-writing-screen/) administration screen of your WordPress installation.
+
+![Screenshot of the Update Services screen.](https://wordpress.org/support/files/2018/10/update_service.png)
+
+Certain web hosts – particularly free ones – disable the PHP functions used to alert update services. If your web host prevents pings, you should stop WordPress from attempting to ping.
+
+## XML-RPC Ping Services
+
+```
+http://rpc.pingomatic.com
+http://rpc.twingly.com
+http://www.blogdigger.com/RPC2
+http://ping.blo.gs/
+http://ping.feedburner.com
+http://rpc.weblogs.com/RPC2
+http://www.pingmyblog.com
+```
+
+## Alternatives
+An alternative is [Feed Shark](https://feedshark.brainbliss.com/), which pings over 60 services for free.
+
+## WordPress Multisite Network
+By default, editing the Ping Services for a WordPress Multisite network site is disabled. This can be re-enabled with a plugin such as the [Activate Update Services](https://wordpress.org/plugins/activate-update-services/) plugin.
 
 
 ## Changelog
 
 - 2022-09-04: Nothing here, yet.
+- 2022-09-11: Migrated content from https://wordpress.org/support/article/update-services/


### PR DESCRIPTION
I did replace the "ping-o-matic" quote, because the old one couldn't be found on their site (and one of the two sites to which it referred, no longer exists).