### PR TITLE
Initial migrate of JS debug page

### DIFF
--- a/debug/debug-javascript.md
+++ b/debug/debug-javascript.md
@@ -1,7 +1,6 @@
 # Using Your Browser to Diagnose JavaScript Errors
 
-
-If you’re experiencing issues with your interactive functionality this may be due to JavaScript errors or conflicts. For example, your flyout menus may be broken, your metaboxes don’t drag, or your add media buttons aren’t working. In order to formulate your support request it helps the team to know what the JavaScript error is.
+If you're experiencing issues with your interactive functionality this may be due to JavaScript errors or conflicts. For example, your flyout menus may be broken, your metaboxes don't drag, or your add media buttons aren't working. In order to formulate your support request it helps the team to know what the JavaScript error is.
 
 This guide will show you how to diagnose JavaScript issues in different browsers.
 
@@ -16,7 +15,7 @@ Make note of any browsers you are experiencing the error in. You can use this in
 
 ## Step 2: Enable SCRIPT_DEBUG
 
-You need to turn on [script debugging](https://wordpress.org/support/article/debugging-in-wordpress#SCRIPT_DEBUG). Open wp-config.php and add the following line before “That’s all, stop editing! Happy blogging”.
+You need to turn on [script debugging](https://wordpress.org/support/article/debugging-in-wordpress#SCRIPT_DEBUG). Open `wp-config.php` and add the following line before "That's all, stop editing! Happy blogging".
 
 ```
 define('SCRIPT_DEBUG', true);
@@ -31,12 +30,11 @@ Check to see if you are still having an issue.
 
 ### Open the Developer Tools 
 
-* Chrome: Type Cmd-Option-J (Mac) or Ctrl-Shift-J (Windows, Linux, Chrome OS), or nagivate to View -> Developer -> Developer Tools in the menu.
-* Firefox: Type Cmd-Option-K (Mad) or Ctrl-Shift-K (Windows, Linux, Chrome OS), or navigate to Web Development -> Web Console in the menu.
-* Edge: Follow the instructions for Chrome.
-* Safari: First, navigate to Safari -> Preferences. Click on the Advanced tab, then check "Show Develop Menu in menu bar". Then, in the new Develop menu, navigate to "Show JavaScript Console".
-* Opera: Navigate to Tools -> Advanced -> Error Console in the menu.
-
+* **Chrome**: Type `Cmd-Option-J` (Mac) or `Ctrl-Shift-J` (Windows, Linux, Chrome OS), or nagivate to `View -> Developer -> Developer Tools` in the menu.
+* **Firefox**: Type `Cmd-Option-K` (Mad) or `Ctrl-Shift-K` (Windows, Linux, Chrome OS), or navigate to `Web Development -> Web Console` in the menu.
+* **Edge**: Follow the instructions for Chrome.
+* **Safari**: First, navigate to `Safari -> Preferences`. Click on the `Advanced` tab, then check `Show Develop Menu in menu bar`. Then, in the new `Develop` menu, navigate to `Show JavaScript Console`.
+* **Opera**: Navigate to `Tools -> Advanced -> Error Console` in the menu.
 
 ### Identify The Error
 
@@ -44,7 +42,7 @@ Often, the text of the error will already be visible in the console. It may look
 
 ![Screenshot of an example developer tools error page.](https://wordpress.org/support/files/2020/07/chrome-devtools.png)
 
-The image above shows the error to be in jquery.js on line 2, however remember to copy the whole stack information! Just saying what line is less helpful that showing context.
+The image above shows the error to be in `jquery.js on line 2`, however remember to copy the whole stack information! Just saying what line is less helpful that showing context.
 
 If no errors are displayed, reload the page; many errors occur only when the page is first loaded.
 
@@ -52,7 +50,7 @@ If no errors are displayed, reload the page; many errors occur only when the pag
 
 Now that you have diagnosed your error, you should make your support forum request. Go to the [troubleshooting forum](https://wordpress.org/support/forum/how-to-and-troubleshooting).
 
-If your problem is with a specific theme or plugin, you can access their dedicated support forum by visiting https://wordpress.org/support/plugin/PLUGINNAME or https://wordpress.org/support/theme/THEMENAME
+If your problem is with a specific theme or plugin, you can access their dedicated support forum by visiting `https://wordpress.org/support/plugin/PLUGINNAME` or `https://wordpress.org/support/theme/THEMENAME`.
 
 Please include the below information:
 
@@ -63,9 +61,6 @@ Please include the below information:
 * the context of the error – including the whole error stack will help developers
 * If possible, a link to the web page showing the error
 
-
 ## Changelog
 
-- 2022-09-04: Nothing here, yet.
 - 2022-09-11: Copied content from https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/. Consolidated Developer Tools instuctions, removed IE documentation.
-

--- a/debug/debug-javascript.md
+++ b/debug/debug-javascript.md
@@ -1,10 +1,71 @@
 # Using Your Browser to Diagnose JavaScript Errors
 
-ORIGINAL CONTENT:
-* https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/
 
+If you’re experiencing issues with your interactive functionality this may be due to JavaScript errors or conflicts. For example, your flyout menus may be broken, your metaboxes don’t drag, or your add media buttons aren’t working. In order to formulate your support request it helps the team to know what the JavaScript error is.
+
+This guide will show you how to diagnose JavaScript issues in different browsers.
+
+## Step 1: Try Another Browser
+
+Different browsers often implement parts of JavaScript differently. To make sure that this is a JavaScript error, and not a browser error, first of all try opening your site in another browser.
+
+* if the site is not having the same issue in the new browser you know that the error is browser specific
+* if the site is having the same error it is not an error that is specific to one browser
+
+Make note of any browsers you are experiencing the error in. You can use this information when you are making a support request.
+
+## Step 2: Enable SCRIPT_DEBUG
+
+You need to turn on [script debugging](https://wordpress.org/support/article/debugging-in-wordpress#SCRIPT_DEBUG). Open wp-config.php and add the following line before “That’s all, stop editing! Happy blogging”.
+
+```
+define('SCRIPT_DEBUG', true);
+```
+
+Check to see if you are still having an issue.
+
+* **Issue is fixed** – turn off script debugging and report the issue on the support forum, telling the volunteers that you turned on script debugging and it solved the problem.
+* **Issue persists** – proceed to Step 3.
+
+## Step 3: Diagnosis
+
+### Open the Developer Tools 
+
+* Chrome: Type Cmd-Option-J (Mac) or Ctrl-Shift-J (Windows, Linux, Chrome OS), or nagivate to View -> Developer -> Developer Tools in the menu.
+* Firefox: Type Cmd-Option-K (Mad) or Ctrl-Shift-K (Windows, Linux, Chrome OS), or navigate to Web Development -> Web Console in the menu.
+* Edge: Follow the instructions for Chrome.
+* Safari: First, navigate to Safari -> Preferences. Click on the Advanced tab, then check "Show Develop Menu in menu bar". Then, in the new Develop menu, navigate to "Show JavaScript Console".
+* Opera: Navigate to Tools -> Advanced -> Error Console in the menu.
+
+
+### Identify The Error
+
+Often, the text of the error will already be visible in the console. It may look similar to this:
+
+![Screenshot of an example developer tools error page.](https://wordpress.org/support/files/2020/07/chrome-devtools.png)
+
+The image above shows the error to be in jquery.js on line 2, however remember to copy the whole stack information! Just saying what line is less helpful that showing context.
+
+If no errors are displayed, reload the page; many errors occur only when the page is first loaded.
+
+## Step 4: Reporting
+
+Now that you have diagnosed your error, you should make your support forum request. Go to the [troubleshooting forum](https://wordpress.org/support/forum/how-to-and-troubleshooting).
+
+If your problem is with a specific theme or plugin, you can access their dedicated support forum by visiting https://wordpress.org/support/plugin/PLUGINNAME or https://wordpress.org/support/theme/THEMENAME
+
+Please include the below information:
+
+* the browsers that you are experiencing the problem in
+* whether `SCRIPT_DEBUG` fixed the error or not
+* the JavaScript error
+* the location of the error – both the file name and the line number
+* the context of the error – including the whole error stack will help developers
+* If possible, a link to the web page showing the error
 
 
 ## Changelog
 
 - 2022-09-04: Nothing here, yet.
+- 2022-09-11: Copied content from https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/. Consolidated Developer Tools instuctions, removed IE documentation.
+


### PR DESCRIPTION
Copied page content. Restructured the "how to get to the JS console" part a bit, to make it less clumsy. Removed Internet Explorer.