### PR TITLE
Add trailing slashes to XML-RPC Ping Services examples.

### DIFF
--- a/wordpress/update-services.md
+++ b/wordpress/update-services.md
@@ -18,8 +18,8 @@ Certain web hosts – particularly free ones – disable the PHP functions used 
 ## XML-RPC Ping Services
 
 ```
-https://rpc.pingomatic.com
-https://rpc.twingly.com
+https://rpc.pingomatic.com/
+https://rpc.twingly.com/
 http://ping.blo.gs/
 ```
 


### PR DESCRIPTION
Consistent with other docs.

Closes #431