### PR TITLE
Add password recovery details to logging-in documentation

### DIFF
--- a/security/logging-in.md
+++ b/security/logging-in.md
@@ -1,4 +1,15 @@
 # Your password
+## Password recovery
+
+If you forget your WordPress password, use the **Lost your password?** link on the login screen.
+WordPress will email a password reset link to the address associated with your account.
+
+### Best practices
+- Keep your account email address up to date.
+- Use a strong, unique password after resetting.
+- Avoid sharing login credentials.
+
+For more details, refer to the official WordPress password recovery documentation.
 
 Creating an extension [of this post about resetting your password](https://wordpress.org/documentation/article/resetting-your-password/), but placing all technical details here.
 


### PR DESCRIPTION
This PR adds password recovery information to the Logging In documentation,
as requested in issue #155.
