### PR TITLE
Fix "Many web hosts" link in How to install WordPress

### DIFF
--- a/before-install/howto-install.md
+++ b/before-install/howto-install.md
@@ -1,6 +1,6 @@
 # How to install WordPress
 
-WordPress is well-known for its ease of installation. Under most circumstances, installing WordPress is a very simple process and takes less than five minutes to complete. [Many web hosts](#) now offer [tools (e.g. Fantastico) to automatically install WordPress](https://wordpress.org/documentation/article/automated-installation/) for you. However, if you wish to install WordPress yourself, the following guide will help.
+WordPress is well-known for its ease of installation. Under most circumstances, installing WordPress is a very simple process and takes less than five minutes to complete. [Many web hosts](https://wordpress.org/hosting/) now offer [tools (e.g. Fantastico) to automatically install WordPress](https://wordpress.org/documentation/article/automated-installation/) for you. However, if you wish to install WordPress yourself, the following guide will help.
 
 ## Things to Know Before Installing WordPress
 


### PR DESCRIPTION
## Summary
This PR updates the "Many web hosts" link in the "How to install WordPress" page.

## What changed
- Replaced `[Many web hosts](#)` with:
  `https://wordpress.org/hosting/`

## Why
The current link points to `#` and is not useful for readers.

Fixes WordPress/Documentation-Issue-Tracker#2179
