### PR TITLE
Update troubleshooting forum link in documentation

### DIFF
--- a/debug/debug-javascript.md
+++ b/debug/debug-javascript.md
@@ -48,7 +48,7 @@ If no errors are displayed, reload the page; many errors occur only when the pag
 
 ## Step 4: Reporting
 
-Now that you have diagnosed your error, you should make your support forum request. Go to the [troubleshooting forum](https://wordpress.org/documentation/forum/how-to-and-troubleshooting).
+Now that you have diagnosed your error, you should make your support forum request. Go to the [troubleshooting forum](https://wordpress.org/support/forum/how-to-and-troubleshooting/).
 
 If your problem is with a specific theme or plugin, you can access their dedicated support forum by visiting https://wordpress.org/support/plugin/PLUGINNAME or https://wordpress.org/support/theme/THEMENAME.
 


### PR DESCRIPTION
Update troubleshooting forum link in documentation.

Related to this issue: https://github.com/WordPress/Documentation-Issue-Tracker/issues/960