### PR TITLE
Fix the link URL for backing up WordPress files

### DIFF
--- a/security/backup.md
+++ b/security/backup.md
@@ -48,7 +48,7 @@ There are two parts to backing up your WordPress site: **Database** and **Files*
 
 For step-by-step instructions, see:
 
-- [Backing Up Your WordPress Files](https://developer.wordpress.org/advanced-administration/security/backup-files/)
+- [Backing Up Your WordPress Files](https://developer.wordpress.org/advanced-administration/security/backup/files/)
 - [Backing Up Your Database](https://developer.wordpress.org/advanced-administration/security/backup/database/)
 
 #### Database vs files (why both are needed)


### PR DESCRIPTION
the URL needed to have a hyphen changed to a slash. This had been proposed by PR#494 but had been closed prematurely.